### PR TITLE
:bug: fix .split() is not a function

### DIFF
--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -218,7 +218,9 @@
      * @param mouseEv
      */
     function triggerTouch(eventName, mouseEv) {
-        if (eventName === "touchend" && eventTarget.className.split(" ").indexOf("transition") < 0) {
+        if (eventName === "touchend" &&
+            eventTarget.className &&
+            eventTarget.className.toString().split(" ").indexOf("transition") < 0) {
             return
         }
         var touchEvent = document.createEvent('Event');


### PR DESCRIPTION
Ensure that `eventTarget.className` exists, if so, convert it into a string.

resolves [#2301](https://github.com/goodpatch/prott-webapp/issues/2301)