### PR TITLE
Remove original code

### DIFF
--- a/touch-emulator.js
+++ b/touch-emulator.js
@@ -143,8 +143,8 @@
      * @param ev
      */
     function preventMouseEvents(ev) {
-        // ev.preventDefault();
-        // ev.stopPropagation();
+        ev.preventDefault();
+        ev.stopPropagation();
     }
 
     /**
@@ -218,11 +218,6 @@
      * @param mouseEv
      */
     function triggerTouch(eventName, mouseEv) {
-        if (eventName === "touchend" &&
-            eventTarget.className &&
-            eventTarget.className.toString().split(" ").indexOf("transition") < 0) {
-            return
-        }
         var touchEvent = document.createEvent('Event');
         touchEvent.initEvent(eventName, true, true);
 


### PR DESCRIPTION
独自拡張が原因で不具合が起きまくっているので、ヤバいのを消す

`touchemulator`は主にプレビュー・プレゼンモードにおいて、touch系のイベントを表現するために使われている。
* swipeやpinchなどを設定したトランジションが正しく動作すること
* プレビュー、プレゼンモードの動作に問題がないこと

が確認できれば問題ないと思われる
